### PR TITLE
Update version of Jetty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.socket</groupId>
     <artifactId>socket.io-server-bom</artifactId>
-    <version>4.0.1</version>
+    <version>4.1.0</version>
     <packaging>pom</packaging>
     <name>socket.io</name>
     <description>Socket.IO server library for Java</description>

--- a/socket.io-server-test/pom.xml
+++ b/socket.io-server-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>socket.io-server-bom</artifactId>
         <groupId>io.socket</groupId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -28,13 +28,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -42,32 +42,32 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.19.v20190610</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.19.v20190610</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
-            <version>9.4.19.v20190610</version>
+            <version>9.4.50.v20221201</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>engine.io-server</artifactId>
-            <version>6.1.0</version>
+            <version>6.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.socket</groupId>
             <artifactId>engine.io-server-jetty</artifactId>
-            <version>6.1.0</version>
+            <version>6.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/socket.io-server/pom.xml
+++ b/socket.io-server/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>socket.io-server-bom</artifactId>
         <groupId>io.socket</groupId>
-        <version>4.0.1</version>
+        <version>4.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,9 +16,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20201115</version>
+        </dependency>
+        <dependency>
             <groupId>io.socket</groupId>
             <artifactId>engine.io-server</artifactId>
-            <version>6.1.0</version>
+            <version>6.3.0</version>
         </dependency>
         <dependency>
             <groupId>javax</groupId>
@@ -37,13 +42,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.12.1</version>
+            <version>4.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR follows the updates to [engine.io-server-java](https://github.com/socketio/engine.io-server-java) in https://github.com/socketio/engine.io-server-java/pull/57.

This PR updates the version of Jetty to `9.4.50.v20221201`, alongside updates to some testing libraries to support higher versions of Java.